### PR TITLE
Import all attributes of slideshows and images from 0.5, even those t…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Performance improvements for faster iteration on the import process
 * Removes the package lock file.
 * Import crops correctly
+* Import all attributes of slideshows and images from 0.5, even those that might not have a representation in the equivalent 2.x widget or piece by default, allowing for project-specific workarounds for these
 
 ## 0.1.0 — 0.1.1
 

--- a/index.js
+++ b/index.js
@@ -113,6 +113,8 @@ module.exports = {
           slug: 'a205file' + file._id + '-' + file.name,
           type: (file.group === 'office') ? 'apostrophe-file' : 'apostrophe-image',
           title: file.title,
+          credit: file.credit,
+          description: file.description,
           published: true,
           attachment: attachment
         });
@@ -384,7 +386,11 @@ module.exports = {
           pieceIds: _.map(item.ids || [], function(id) {
             return 'a205file' + id
           }),
-          relationships: relationships
+          relationships: relationships,
+          // These won't actually do anything interesting unless you decide to
+          // custom-implement them in your 2.x project, but bring along the 0.5 data
+          // for completeness
+          ..._.pick(item, 'position', 'size', 'showTitles', 'showDescriptions', 'showCredits')
         };
         return widget;
       });


### PR DESCRIPTION
…hat might not have a representation in the equivalent 2.x widget or piece by default, allowing for project-specific workarounds for these